### PR TITLE
Stabilize byteorder dep to v1.0

### DIFF
--- a/tokio-thrift-lib/Cargo.toml
+++ b/tokio-thrift-lib/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchronous"]
 
 
 [dependencies]
-byteorder = "0.4"
+byteorder = "1.0"
 rustc-serialize = "0.3"
 log = "0.3"
 futures = "0.1.3"

--- a/tokio-thrift-lib/src/protocol/mod.rs
+++ b/tokio-thrift-lib/src/protocol/mod.rs
@@ -2,13 +2,11 @@ pub mod binary_protocol;
 pub use self::binary_protocol::BinaryProtocol;
 
 use std::{io, convert, error, fmt};
-use byteorder;
 use std::string::FromUtf8Error;
 
 #[derive(Debug)]
 pub enum Error {
     EOF,
-    Byteorder(byteorder::Error),
     Io(io::Error),
     Utf8Error(FromUtf8Error),
     BadVersion,
@@ -25,7 +23,6 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match self {
             &Error::EOF => "eof",
-            &Error::Byteorder(_) => "internal error of byteorder",
             &Error::Io(_) => "internal error of io",
             &Error::Utf8Error(_) => "internal error of utf8 conversion",
             &Error::BadVersion => "bad version",
@@ -36,7 +33,6 @@ impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match self {
             &Error::EOF => None,
-            &Error::Byteorder(ref e) => Some(e),
             &Error::Io(ref e) => Some(e),
             &Error::Utf8Error(ref e) => Some(e),
             &Error::BadVersion => None,
@@ -45,15 +41,6 @@ impl error::Error for Error {
     }
 }
 
-
-impl convert::From<byteorder::Error> for Error {
-    fn from(err: byteorder::Error) -> Error {
-        match err {
-            byteorder::Error::UnexpectedEOF => Error::EOF,
-            err => Error::Byteorder(err),
-        }
-    }
-}
 
 impl convert::From<FromUtf8Error> for Error {
     fn from(err: FromUtf8Error) -> Error {

--- a/tokio-thrift-lib/src/result.rs
+++ b/tokio-thrift-lib/src/result.rs
@@ -1,7 +1,6 @@
 use std::io;
 use std::convert;
 use std::sync::PoisonError;
-use byteorder;
 use std::sync::mpsc::{SendError, RecvError};
 use protocol;
 
@@ -11,7 +10,6 @@ pub enum ThriftError {
     NotReady,
     Str(String),
     IO(io::Error),
-    ByteOrder(byteorder::Error),
     PoisonError,
     RecvError(RecvError),
     SendError,
@@ -40,12 +38,6 @@ impl convert::From<protocol::Error> for ThriftError {
 impl convert::From<RecvError> for ThriftError {
     fn from(_val: RecvError) -> ThriftError {
         ThriftError::RecvError(RecvError)
-    }
-}
-
-impl convert::From<byteorder::Error> for ThriftError {
-    fn from(val: byteorder::Error) -> ThriftError {
-        ThriftError::ByteOrder(val)
     }
 }
 


### PR DESCRIPTION
ByteOrder crate has since dropped the special error handling - API now only returns a bare result.